### PR TITLE
Release 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ TODO
   - 0.2.2
 - kotlin 1.3.70
   - 0.3.0
+  - 0.3.1
 
 ## Installation
 root build.gradle  
@@ -44,7 +45,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "dev.icerock.moko:units-generator:0.3.0"
+        classpath "dev.icerock.moko:units-generator:0.3.1"
     }
 }
 
@@ -61,7 +62,7 @@ project build.gradle
 apply plugin: "dev.icerock.mobile.multiplatform-units"
 
 dependencies {
-    commonMainApi("dev.icerock.moko:units:0.3.0")
+    commonMainApi("dev.icerock.moko:units:0.3.1")
 }
 
 multiplatformUnits {
@@ -73,7 +74,7 @@ multiplatformUnits {
 
 On iOS, in addition to the Kotlin library add Pod in the Podfile.
 ```ruby
-pod 'MultiPlatformLibraryUnits', :git => 'https://github.com/icerockdev/moko-units.git', :tag => 'release/0.3.0'
+pod 'MultiPlatformLibraryUnits', :git => 'https://github.com/icerockdev/moko-units.git', :tag => 'release/0.3.1'
 ```
 **`MultiPlatformLibraryUnits` CocoaPod requires that the framework compiled from Kotlin be named 
 `MultiPlatformLibrary` and be connected as a CocoaPod `MultiPlatformLibrary`. 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -11,7 +11,7 @@ object Versions {
 
     const val kotlin = "1.3.70"
 
-    private const val mokoUnits = "0.3.0"
+    private const val mokoUnits = "0.3.1"
 
     object Plugins {
         const val android = "3.6.1"

--- a/units/src/iosMain/kotlin/dev/icerock/moko/units/CollectionUnitsSource.kt
+++ b/units/src/iosMain/kotlin/dev/icerock/moko/units/CollectionUnitsSource.kt
@@ -14,7 +14,7 @@ fun create(
     withReloadHandler: UICollectionViewReloadHandler = { collectionView, _, _ -> collectionView.reloadData() }
 ): CollectionUnitsSource {
     return object: CollectionUnitsSource {
-        private val unitsSource = UnitCollectionViewDataSource.create(forCollectionView, withReloadHandler)
+        private val unitsSource = createUnitCollectionViewDataSource(forCollectionView, withReloadHandler)
         override var unitItems: List<CollectionUnitItem>?
             get() {
                 return unitsSource.unitItems

--- a/units/src/iosMain/kotlin/dev/icerock/moko/units/TableUnitsSource.kt
+++ b/units/src/iosMain/kotlin/dev/icerock/moko/units/TableUnitsSource.kt
@@ -16,7 +16,7 @@ fun create(
 ): TableUnitsSource {
     return object: TableUnitsSource {
 
-        private val unitsSource = UnitTableViewDataSource.create(forTableView, withReloadHandler)
+        private val unitsSource = createUnitTableViewDataSource(forTableView, withReloadHandler)
         override var unitItems: List<TableUnitItem>?
             get() {
                 return unitsSource.unitItems

--- a/units/src/iosMain/kotlin/dev/icerock/moko/units/UnitCollectionViewDataSource.kt
+++ b/units/src/iosMain/kotlin/dev/icerock/moko/units/UnitCollectionViewDataSource.kt
@@ -16,7 +16,7 @@ import platform.darwin.NSObject
 typealias UICollectionViewReloadHandler = (UICollectionView, oldData: List<CollectionUnitItem>?, newData: List<CollectionUnitItem>?) -> Unit
 
 @ExportObjCClass
-class UnitCollectionViewDataSource private constructor(
+class UnitCollectionViewDataSource internal constructor(
     private val collectionView: UICollectionView,
     private val reloadDataHandler: UICollectionViewReloadHandler
 ) : NSObject(), UICollectionViewDataSourceProtocol {
@@ -62,11 +62,9 @@ class UnitCollectionViewDataSource private constructor(
     override fun numberOfSectionsInCollectionView(collectionView: UICollectionView): NSInteger {
         return 1
     }
-
-    companion object {
-        fun create(
-            collectionView: UICollectionView,
-            reloadDataHandler: UICollectionViewReloadHandler = { _collectionView, _, _ -> _collectionView.reloadData() }
-        ) = UnitCollectionViewDataSource(collectionView, reloadDataHandler)
-    }
 }
+
+fun createUnitCollectionViewDataSource(
+    collectionView: UICollectionView,
+    reloadDataHandler: UICollectionViewReloadHandler = { _collectionView, _, _ -> _collectionView.reloadData() }
+) = UnitCollectionViewDataSource(collectionView, reloadDataHandler)

--- a/units/src/iosMain/kotlin/dev/icerock/moko/units/UnitTableViewDataSource.kt
+++ b/units/src/iosMain/kotlin/dev/icerock/moko/units/UnitTableViewDataSource.kt
@@ -16,7 +16,7 @@ import platform.darwin.NSObject
 typealias UITableViewReloadHandler = (UITableView, oldData: List<TableUnitItem>?, newData: List<TableUnitItem>?) -> Unit
 
 @ExportObjCClass
-class UnitTableViewDataSource private constructor(
+class UnitTableViewDataSource internal constructor(
     private val tableView: UITableView,
     private val reloadDataHandler: UITableViewReloadHandler
 ) : NSObject(), UITableViewDataSourceProtocol {
@@ -59,11 +59,9 @@ class UnitTableViewDataSource private constructor(
     override fun numberOfSectionsInTableView(tableView: UITableView): NSInteger {
         return 1
     }
-
-    companion object {
-        fun create(
-            tableView: UITableView,
-            reloadDataHandler: UITableViewReloadHandler = { _tableView, _, _ -> _tableView.reloadData() }
-        ) = UnitTableViewDataSource(tableView, reloadDataHandler)
-    }
 }
+
+fun createUnitTableViewDataSource(
+    tableView: UITableView,
+    reloadDataHandler: UITableViewReloadHandler = { _tableView, _, _ -> _tableView.reloadData() }
+) = UnitTableViewDataSource(tableView, reloadDataHandler)


### PR DESCRIPTION
hofix of ios framework compilation

# Breaking changes
- `UnitTableViewDataSource.create` replaced by `createUnitTableViewDataSource` global fun
- `UnitCollectionViewDataSource.create` replaced by `createUnitCollectionViewDataSource` global fun