### PR TITLE
update swift version to 5

### DIFF
--- a/MultiPlatformLibraryUnits.podspec
+++ b/MultiPlatformLibraryUnits.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
     spec.dependency 'MultiPlatformLibrary'
 
     spec.ios.deployment_target  = '9.0'
-    spec.swift_version = '4.2'
+    spec.swift_version = '5'
 
     spec.default_subspec = 'Core'
 

--- a/sample/ios-app/Podfile.lock
+++ b/sample/ios-app/Podfile.lock
@@ -35,7 +35,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Differ: 5cd747e2f29c11ea9605eba7cb369df17e2b1ee2
   MultiPlatformLibrary: 176fb8ade516666cd47e93de1b71ba0441a541bb
-  MultiPlatformLibraryUnits: 0d2efb66522f63a8b38d5639d329aeb70cd4e9ba
+  MultiPlatformLibraryUnits: 0ea2864f59467778d1cb44d1959eed0cbf279124
   R.swift: 8cbc4fc69b740305b6a17c8a8ed968eb788962d9
   R.swift.Library: fa85ce1e0d0b7e818cd9e080df910ba54d2776cc
 

--- a/sample/ios-app/TestProj.xcodeproj/project.pbxproj
+++ b/sample/ios-app/TestProj.xcodeproj/project.pbxproj
@@ -327,12 +327,13 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = src/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.icerock.moko.sample.units;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = mokoSampleUnits;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -351,7 +352,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Updated MultiplatformLibraryUnits pod and Sample to Swift 5

also added `build active arch only` for debug builds. Without it sample build failed on simulator in Xcode 12. It's still failed for release build on simulator.