### PR TITLE
Fix crash on data source update

### DIFF
--- a/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
+++ b/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
@@ -81,7 +81,12 @@ extension CollectionUnitsSourceKt {
         return CollectionUnitsSourceKt.create(forCollectionView: collectionView) { (view, old, new) in
             
             if collectionView.window == nil {
-                print("Warning: - refresh cells without collectionView being in the view hierarchy may cause a crash")
+                /*
+                 * collectionView is not in view hierarchy here, therefore animation will not be performed and rows will not be reloaded,
+                 * but data source has already been updated.
+                 * reload data here prevent crash on next data source update, when calculated diff is empty, but is not actually empty.
+                 */
+                collectionView.reloadData()
                 return
             }
             

--- a/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
+++ b/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
@@ -14,7 +14,12 @@ extension TableUnitsSourceKt {
         return TableUnitsSourceKt.create(forTableView: tableView) { (view: UITableView, old: Array<TableUnitItem>?, new: Array<TableUnitItem>?) in
             
             if tableView.window == nil {
-                print("Warning: - refresh cells without tableView being in the view hierarchy may cause a crash")
+                /*
+                 * tableView is not in view hierarchy here, therefore animation will not be performed and rows will not be reloaded,
+                 * but data source has already been updated.
+                 * reload data here prevent crash on next data source update, when calculated diff is empty, but is not actually empty.
+                 */
+                tableView.reloadData()
                 return
             }
             


### PR DESCRIPTION
Fix crash on data source update when table view is not in view hierarchy. This fix prevent crash on update which will be performed after unsuccessful animated reload rows.

Linked with [issue](https://github.com/icerockdev/moko-units/issues/59)