### PR TITLE
added calculating prev cell indexPath for diff data source

### DIFF
--- a/sample/ios-app/src/Cells/RedDividerCell.xib
+++ b/sample/ios-app/src/Cells/RedDividerCell.xib
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RedDividerCell" id="b1o-ug-spt" customClass="ComplexCell" customModule="mokoSampleUnits" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RedDividerCell" id="b1o-ug-spt" customClass="RedDividerCell" customModule="mokoSampleUnits" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="b1o-ug-spt" id="6Vu-Tb-KdE">

--- a/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
+++ b/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
@@ -162,23 +162,26 @@ fileprivate extension Array {
 
 fileprivate extension IndexPath {
     
-    // Calculate IndexPath of row before diff was applied
+    // Using new indexPath and diff (traces array), calculate index of cell that was before applying the diff, for preventing reload cells once again.
     func toOldIndexPath(traces: [Trace]) -> IndexPath? {
         
         // filter for only matchedTraces,
         // can't use type() function from here https://github.com/wokalski/Diff.swift/blob/61edde253f8b74ab475dfc0dd40941efacdff71d/Sources/Diff.swift#L97
         // because it is internal
         let matchedTraces = traces.filter { trace in
+            // Trace is a vector with coords (from, to) that shows changes of cell position
+            // if trace is a horizontal vector, it means row is deleted
+            // if trace is vertical vector, it means row is inserted
+            // we only need diagonal vectors, it means that row wasn't deleted or inserted
             trace.from.x + 1 == trace.to.x && trace.from.y + 1 == trace.to.y
         }
         
         // trace.from.y - current row index
-        // trace.from.x - old row index
-        
         guard let trace = (matchedTraces.first { $0.from.y == self.row }) else {
             return nil
         }
         
+        // trace.from.x - old row index
         return IndexPath(row: trace.from.x, section: 0)
     }
 }

--- a/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
+++ b/units/src/iosMain/swift/Differ/UnitsSource+Diffable.swift
@@ -46,7 +46,7 @@ extension TableUnitsSourceKt {
                     return noId || notInsertOrDelete
                 }
                 let cellsForReload: Array<IndexPath> = cellsToUpdate.filter { indexPath in
-                    let oldItem: TableUnitItem? = old?.getSafe(indexPath: indexPath)
+                    let oldItem: TableUnitItem? = old?.getSafe(indexPath: indexPath.toOldIndexPath(diff: diff))
                     let newItem: TableUnitItem? = new?.getSafe(indexPath: indexPath)
                     
                     if let oldItem = oldItem, let newItem = newItem,
@@ -108,7 +108,7 @@ extension CollectionUnitsSourceKt {
                     return noId || notInsertOrDelete
                 }
                 let cellsForReload: Array<IndexPath> = cellsToUpdate.filter { indexPath in
-                    let oldItem: CollectionUnitItem? = old?.getSafe(indexPath: indexPath)
+                    let oldItem: CollectionUnitItem? = old?.getSafe(indexPath: indexPath.toOldIndexPath(diff: diff))
                     let newItem: CollectionUnitItem? = new?.getSafe(indexPath: indexPath)
                     
                     if let oldItem = oldItem, let newItem = newItem,
@@ -145,6 +145,33 @@ fileprivate extension Array {
         } else {
             return nil
         }
+    }
+}
+
+fileprivate extension IndexPath {
+    
+    // Calculate IndexPath of row before diff was applied
+    func toOldIndexPath(diff: ExtendedDiff) -> IndexPath {
+        var oldRow = self.row
+        diff.elements.reversed().forEach { element in
+            switch element {
+            case let .delete(at):
+                if at <= oldRow {
+                    oldRow += 1
+                }
+            case let .insert(at):
+                if at < oldRow {
+                    oldRow -= 1
+                }
+            case let .move(from, to):
+                if from > oldRow && to < oldRow {
+                    oldRow -= 1
+                } else if from < oldRow && to > oldRow {
+                    oldRow += 1
+                }
+            }
+        }
+        return IndexPath(row: oldRow, section: 0)
     }
 }
 


### PR DESCRIPTION
Fix for comparing TableUnitItems in diffable datasource. IndexPath of cell can be changed after inserting and deleting rows. So getting unit item from old data array with new IndexPath is not right. Added calculating IndexPath of row before diff was applied.